### PR TITLE
Add TOC to landing page. Insert link to Google groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,14 @@ notebooks. To see the rendered notebooks, browse the directories above or visit 
     
 ## Frequently Asked Questions
 
-**How do I use Cantera with Python**
+**How do I use Cantera with Python?**
 
-To learn how to use Cantera with Python, click [here](http://cantera.github.io/docs/sphinx/html/cython/index.html). For more advanced uses of Cantera, the complete documentation can be found [here](http://cantera.github.io/docs/sphinx/html/index.html)
+To learn how to use Cantera with Python, click [here](http://cantera.github.io/docs/sphinx/html/cython/index.html). For more advanced uses of Cantera, the complete documentation can be found [here](http://cantera.github.io/docs/sphinx/html/index.html).
 
-**Can I forgo installing Cantera locally and just use Cantera in the cloud every time**
+**Can I forgo installing Cantera locally and just use Cantera in the cloud every time?**
 
 The problem with using Cantera with Binder is that there is no way for you to save your work. You can upload/download files in a session, but once the session is over (you close your browser window), you lose all your work. You thus cannot save your modified iPython notebooks. 
 
 **I still can't figure something out. Who do I ask?**
 
-If you have more questions, need help with something, or have any suggestions, please visit [Cantera Google Groups Page](https://groups.google.com/forum/#!forum/cantera-users) and create a post
+If you have more questions, need help with something, or have any suggestions, please visit the [Cantera Google Groups Page](https://groups.google.com/forum/#!forum/cantera-users) and create a post.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ notebooks. To see the rendered notebooks, browse the directories above or visit 
 [![Binder](http://mybinder.org/badge.svg)](http://mybinder.org:/repo/cantera/cantera-jupyter)
 
 ## Examples
-***
 
 * Basic Thermodynamics Calculations
     * [Fuel heating value calculator](https://github.com/Cantera/cantera-jupyter/blob/master/thermo/heating_value.ipynb)
@@ -21,7 +20,6 @@ notebooks. To see the rendered notebooks, browse the directories above or visit 
     * [Counter-flow twin premixed flame simulator](https://github.com/Cantera/cantera-jupyter/blob/master/flames/twin_premixed_flame_axisymmetric.ipynb)
     
 ## Frequently Asked Questions
-***
 
 **How do I use Cantera with Python**
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ notebooks. To see the rendered notebooks, browse the directories above or visit 
 
 To learn how to use Cantera with Python, click [here](http://cantera.github.io/docs/sphinx/html/cython/index.html). For more advanced uses of Cantera, the complete documentation can be found [here](http://cantera.github.io/docs/sphinx/html/index.html)
 
+**Can I forgo installing Cantera locally and just use Cantera in the cloud every time**
+
+The problem with using Cantera with Binder is that there is no way for you to save your work. You can upload/download files in a session, but once the session is over (you close your browser window), you lose all your work. You thus cannot save your modified iPython notebooks. 
+
 **I still can't figure something out. Who do I ask?**
 
 If you have more questions, need help with something, or have any suggestions, please visit [Cantera Google Groups Page](https://groups.google.com/forum/#!forum/cantera-users) and create a post

--- a/README.md
+++ b/README.md
@@ -1,7 +1,26 @@
 # cantera-jupyter
 [Cantera](http://cantera.org) examples in the form of [Jupyter](http://jupyter.org)
-notebooks. To see the rendered notebooks, browse the directories above. To run any
-of these examples yourself, follow the Binder link below to launch an interactive
-environment where you can try using Cantera -- no installation required.
+notebooks. To see the rendered notebooks, browse the directories above or vist the links in the list of examples below.
+
+**Existing Cantera users**: If you have [Cantera](http://cantera.org) and [Jupyter](http://jupyter.org) installed on your local machine, simply download any iPython notebook and you should be able to run it.
+
+**New Cantera Users**: If you don't have an exiting Cantera installation, you can now run Cantera in the cloud ! *No installation required*. Click on the Binder link below to launch an interactive environment where you can run these examples.
 
 [![Binder](http://mybinder.org/badge.svg)](http://mybinder.org:/repo/cantera/cantera-jupyter)
+
+### Examples
+***
+
+* Basic Thermodynamics Calculations
+    1. [Fuel heating value calculator](https://github.com/Cantera/cantera-jupyter/blob/master/thermo/heating_value.ipynb)
+    2. [Equilibrium flame temperature calculator](https://github.com/Cantera/cantera-jupyter/blob/master/thermo/flame_temperature.ipynb)
+
+* Flame Simulations
+
+    1. [Flame speed calculator with sensitivity analysis](https://github.com/Cantera/cantera-jupyter/blob/master/flames/flame_speed_with_sensitivity_analysis.ipynb)
+    2. [Counter-flow twin premixed flame simulator](https://github.com/Cantera/cantera-jupyter/blob/master/flames/twin_premixed_flame_axisymmetric.ipynb)
+    
+### Questions/Doubts/Comments
+***
+
+If you have any questions, need help with something, or have any suggestions, please visit [Cantera Google Groups Page](https://groups.google.com/forum/#!forum/cantera-users) and create a post

--- a/README.md
+++ b/README.md
@@ -1,26 +1,32 @@
 # cantera-jupyter
 [Cantera](http://cantera.org) examples in the form of [Jupyter](http://jupyter.org)
-notebooks. To see the rendered notebooks, browse the directories above or vist the links in the list of examples below.
+notebooks. To see the rendered notebooks, browse the directories above or visit the links in the list of examples below.
 
 **Existing Cantera users**: If you have [Cantera](http://cantera.org) and [Jupyter](http://jupyter.org) installed on your local machine, simply download any iPython notebook and you should be able to run it.
 
-**New Cantera Users**: If you don't have an exiting Cantera installation, you can now run Cantera in the cloud ! *No installation required*. Click on the Binder link below to launch an interactive environment where you can run these examples.
+**New Cantera Users**: If you don't have an exiting Cantera installation, you can either [download and install Cantera](http://cantera.github.io/docs/sphinx/html/install.html) or try to run Cantera in the cloud for a test drive. Click on the Binder link below to launch an interactive environment where you can run these examples. For this, there is no installation required. 
 
 [![Binder](http://mybinder.org/badge.svg)](http://mybinder.org:/repo/cantera/cantera-jupyter)
 
-### Examples
+## Examples
 ***
 
 * Basic Thermodynamics Calculations
-    1. [Fuel heating value calculator](https://github.com/Cantera/cantera-jupyter/blob/master/thermo/heating_value.ipynb)
-    2. [Equilibrium flame temperature calculator](https://github.com/Cantera/cantera-jupyter/blob/master/thermo/flame_temperature.ipynb)
+    * [Fuel heating value calculator](https://github.com/Cantera/cantera-jupyter/blob/master/thermo/heating_value.ipynb)
+    * [Equilibrium flame temperature calculator](https://github.com/Cantera/cantera-jupyter/blob/master/thermo/flame_temperature.ipynb)
 
 * Flame Simulations
 
-    1. [Flame speed calculator with sensitivity analysis](https://github.com/Cantera/cantera-jupyter/blob/master/flames/flame_speed_with_sensitivity_analysis.ipynb)
-    2. [Counter-flow twin premixed flame simulator](https://github.com/Cantera/cantera-jupyter/blob/master/flames/twin_premixed_flame_axisymmetric.ipynb)
+    * [Flame speed calculator with sensitivity analysis](https://github.com/Cantera/cantera-jupyter/blob/master/flames/flame_speed_with_sensitivity_analysis.ipynb)
+    * [Counter-flow twin premixed flame simulator](https://github.com/Cantera/cantera-jupyter/blob/master/flames/twin_premixed_flame_axisymmetric.ipynb)
     
-### Questions/Doubts/Comments
+## Frequently Asked Questions
 ***
 
-If you have any questions, need help with something, or have any suggestions, please visit [Cantera Google Groups Page](https://groups.google.com/forum/#!forum/cantera-users) and create a post
+**How do I use Cantera with Python**
+
+To learn how to use Cantera with Python, click [here](http://cantera.github.io/docs/sphinx/html/cython/index.html). For more advanced uses of Cantera, the complete documentation can be found [here](http://cantera.github.io/docs/sphinx/html/index.html)
+
+**I still can't figure something out. Who do I ask?**
+
+If you have more questions, need help with something, or have any suggestions, please visit [Cantera Google Groups Page](https://groups.google.com/forum/#!forum/cantera-users) and create a post


### PR DESCRIPTION
Change the landing page to make it more informative. Users now need not click on each folder to see what lurks beneath. Add a link to google groups so that users can post questions for help

Use the word "cloud" because that makes it clear to most users that there is web-version that can be used in minutes