### PR TITLE
Cantera Python Tutorial

### DIFF
--- a/canteraPythonTutorial.ipynb
+++ b/canteraPythonTutorial.ipynb
@@ -1,0 +1,2691 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Cantera Tutorial: Python"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Getting Started"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true
+   },
+   "source": [
+    "Open a new Jupyter Notebook. If unfamiliar with Jupyter Notebooks see the [Jupyter Documentation](https://jupyter.readthedocs.io/en/latest/install.html) for installation and basic use instructions. Import the Cantera Python module and NumPy by running:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import cantera as ct\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "When using Cantera, the first thing you usually need is an object representing some phase of matter. Here, we'll create a gas mixture:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "gas1 = ct.Solution('gri30.xml')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To view the state of the mixture, *call* the **gas1** object as if it were a function:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  gri30:\n",
+      "\n",
+      "       temperature             300  K\n",
+      "          pressure          101325  Pa\n",
+      "           density       0.0818891  kg/m^3\n",
+      "  mean mol. weight         2.01588  amu\n",
+      "\n",
+      "                          1 kg            1 kmol\n",
+      "                       -----------      ------------\n",
+      "          enthalpy           26470        5.336e+04     J\n",
+      "   internal energy     -1.2109e+06       -2.441e+06     J\n",
+      "           entropy           64914        1.309e+05     J/K\n",
+      "    Gibbs function     -1.9448e+07        -3.92e+07     J\n",
+      " heat capacity c_p           14312        2.885e+04     J/K\n",
+      " heat capacity c_v           10187        2.054e+04     J/K\n",
+      "\n",
+      "                           X                 Y          Chem. Pot. / RT\n",
+      "                     -------------     ------------     ------------\n",
+      "                H2              1                1         -15.7173\n",
+      "     [  +52 minor]              0                0\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "gas1()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "What you have just done is created an object **gas1** that implements GRI-Mech 3.0, the 53-species, 325-reaction natural gas combustion mechanism developed by Gregory P. Smith, David M. Golden, Michael Frenklach, Nigel W. Moriarty, Boris Eiteneer, Mikhail Goldenberg, C. Thomas Bowman, Ronald K. Hanson, Soonho Song, William C. Gardiner, Jr., Vitali V. Lissianski, and Zhiwei Qin.  See the [GRI-Mech Home Page](http://combustion.berkeley.edu/gri-mech/) for more information.\n",
+    "\n",
+    "The **gas1** object has properties you would expect for a gas mixture: a temperature, a pressure, species mole and mass fractions, etc. As we will soon see, it has many more properties.\n",
+    "\n",
+    "The summary of the state of **gas1** that you found above shows that the new objects created from the **gri30.xml** input file start out with a temperature of 300 K, a pressure of 1 atm, and have a composition that consists of only one species, in this case hydrogen. There is nothing special about H2 - it just happens to be the first species listed in the input file defining GRI-Mech 3.0. In general, whichever species is listed first will initially have a mole fraction of 1.0, and all others will be zero."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setting the State"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The state of the object can easily be changed. For example:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "gas1.TP = 1200, 101325"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "sets the temperature to 1200 K and the pressure to 101325 Pa (Cantera always uses SI Units). After this statement, calling `gas1()` results in:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  gri30:\n",
+      "\n",
+      "       temperature            1200  K\n",
+      "          pressure          101325  Pa\n",
+      "           density       0.0204723  kg/m^3\n",
+      "  mean mol. weight         2.01588  amu\n",
+      "\n",
+      "                          1 kg            1 kmol\n",
+      "                       -----------      ------------\n",
+      "          enthalpy      1.3296e+07         2.68e+07     J\n",
+      "   internal energy      8.3462e+06        1.682e+07     J\n",
+      "           entropy           85228        1.718e+05     J/K\n",
+      "    Gibbs function     -8.8978e+07       -1.794e+08     J\n",
+      " heat capacity c_p           15378          3.1e+04     J/K\n",
+      " heat capacity c_v           11253        2.269e+04     J/K\n",
+      "\n",
+      "                           X                 Y          Chem. Pot. / RT\n",
+      "                     -------------     ------------     ------------\n",
+      "                H2              1                1         -17.9775\n",
+      "     [  +52 minor]              0                0\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "gas1()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Notice that the temperature has been changed as requested, but the pressure has changed too. The density and the composition have not.\n",
+    "\n",
+    "Thermodynamics generally requires that *two* properties in addition to composition information be specified to fix the intensive state of a substance (or mixture). The state of the mixture can be set using several combinations of two properties. The following are all equivalent:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "gas1.TP = 1200, 101325            # temperature, pressure\n",
+    "gas1.TD = 1200, 0.0204723         # temperature, density\n",
+    "gas1.HP = 1.32956e7, 101325       # specific enthalpy, pressure\n",
+    "gas1.UV = 8.34619e6, 1/0.0204723  # specific internal energy, specific volume\n",
+    "gas1.SP = 85227.6, 101325         # specific entropy, pressure\n",
+    "gas1.SV = 85227.6, 1/0.0204723    # specific entropy, specific volume"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In each case, the values of the extensive properties must be entered *per unit mass*.\n",
+    "\n",
+    "Properties may be read independently, such as"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1200.0044548350836"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "gas1.T"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "or"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "13295636.190310445"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "gas1.h"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "or together:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(8346238.627182945, 48.84649013545132)"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "gas1.UV"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The composition can be set in terms of either mole fractions (`X`) or mass fractions (`Y`):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "gas1.X = 'CH4:1, O2:2, N2:7.52'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Mass and mole fractions can also be set using the **`dict`** objects, for cases where the composition is stored in a variable or being computed:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "phi = 0.8\n",
+    "gas1.X = {'CH4':1, 'O2':2/phi, 'N2': 2*3.76/phi}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "When the composition alone is changed, the temperature and density are held constant. This means that the pressure and other intensive properties will change. The composition can also be set in conjunction with the intensive properties of the mixture:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "  gri30:\n",
+      "\n",
+      "       temperature            1200  K\n",
+      "          pressure          101325  Pa\n",
+      "           density        0.280629  kg/m^3\n",
+      "  mean mol. weight         27.6332  amu\n",
+      "\n",
+      "                          1 kg            1 kmol\n",
+      "                       -----------      ------------\n",
+      "          enthalpy      8.6194e+05        2.382e+07     J\n",
+      "   internal energy      5.0088e+05        1.384e+07     J\n",
+      "           entropy          8914.3        2.463e+05     J/K\n",
+      "    Gibbs function     -9.8352e+06       -2.718e+08     J\n",
+      " heat capacity c_p          1397.3        3.861e+04     J/K\n",
+      " heat capacity c_v          1096.4         3.03e+04     J/K\n",
+      "\n",
+      "                           X                 Y          Chem. Pot. / RT\n",
+      "                     -------------     ------------     ------------\n",
+      "                O2       0.190114         0.220149         -28.7472\n",
+      "               CH4       0.095057        0.0551863          -35.961\n",
+      "                N2       0.714829         0.724665         -25.6789\n",
+      "     [  +50 minor]              0                0\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "gas1.TPX = 1200, 101325, 'CH4:1, O2:2, N2:7.52'\n",
+    "gas1()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The composition above was specified using a string. The format is a comma-separated list of `<species name>:<relative mole numbers>` pairs. The mole numbers will be normalized to produce the mole fractions, and therefore they are \"relative\" mole numbers. Mass fractions can be set this way too by changing `X` to `Y` in the above statements.\n",
+    "\n",
+    "The composition can also be set using an array, which must have the same size as the number of species. For example, to set all 53 mole fractions to the same value, do this:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "gas1.X = np.ones(53)  # NumPy array of 53 ones"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Or, to set all the mass fractions to equal values:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "gas1.Y = np.ones(53)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "When setting the state, you can control what properties are held constant by passing the special value **`None`** to the property setter. For example, to change the specific volume to 2.1 m^3/kg while holding entropy constant:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "gas1.SV = None, 2.1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Or to set the mass fractions while holding temperatures and pressure constant:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "gas1.TPX = None, None, 'CH4:1.0, O2:0.5'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Working with a Subset of Species"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Many properties of a [Solution](http://cantera.github.io/docs/sphinx/html/cython/importing.html#cantera.Solution) provide values for each species present in the phase. If you want to get values only for a subset of these species, you can use Python's \"slicing\" syntax to select data for just the species of interest. To get the mole fractions of just the major species in **`gas1`**, in the order specified, you can write:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "Xmajor = gas1['CH4','O2','CO2','H2O','N2'].X"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you want to use the same set of species repeatedly, you can keep a reference to the sliced phase object:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "major = gas1['CH4','O2','CO2','H2O','N2']\n",
+    "cp_major = major.partial_molar_cp\n",
+    "wdot_major = major.net_production_rates"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The slice object and the original object share the same internal state, so modifications to one will affect the other."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Working with Mechanism Files"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In the previous example, we created an object that models an ideal gas mixture with the species and reactions of GRI-Mech 3.0, using the `gri30.xml` input file included with Cantera. This is a \"pre-processed\" XML input file written in a format that is easy for Cantera to parse. Cantera also supports an input file format that is easier to write, called *CTI*. Several reaction mechanism files in this format are included with Cantera, including ones that model high-temperature air, a hydrogen/oxygen reaction mechanism, and a few surface reaction mechanisms. These files are usually located in the `data` subdirectory of the Cantera installation directory, e.g. `C:\\\\Program Files\\\\Cantera\\\\data` on Windows or `/usr/local/cantera/data/` on Unix/Linux/Mac OS X machines, depending on how you installed Cantera and the options you specified.\n",
+    "\n",
+    "If, for some reason, Cantera has difficulty finding where these files are on your system, set environment variable `CANTERA_DATA` to the directory or directories (separated using `;` on Windows or `:` on other operating systems) where they are located. Alternatively, you can call function **[add_directory](http://cantera.github.io/docs/sphinx/html/cython/importing.html#cantera.add_directory)** to add a directory to the Cantera search path:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "ct.add_directory('/usr/local/cantera/my_data_files')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Cantera input files are plain text files, and can be created with any text editor. See the document *[Defining Phases](http://cantera.github.io/docs/sphinx/html/cti/index.html#sec-defining-phases)* for more information.\n",
+    "\n",
+    "A Cantera input file may contain more than one phase specification, or may contain specifications of interfaces (surfaces). Here, we import definitions of two bulk phases and the interface between them from the file `diamond.cti`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "gas2 = ct.Solution('diamond.cti', 'gas')\n",
+    "diamond = ct.Solution('diamond.cti', 'diamond')\n",
+    "diamond_surf = ct.Interface('diamond.cti', 'diamond_100', [gas2, diamond])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that the bulk (i.e., 3D or homogenous) phases that participate in the surface reactions must also be passed as arguments to **[Interface](http://cantera.github.io/docs/sphinx/html/cython/importing.html#cantera.Interface)**."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Converting CK-format files"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "See *[Converting CK-format files](http://cantera.github.io/docs/sphinx/html/cti/input-files.html#sec-ck-format-conversion)* in the *[Working with Input Files](http://cantera.github.io/docs/sphinx/html/cti/input-files.html#sec-input-files)* documentation."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Getting Help"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In addition to the Sphinx-generated *[Python Module Documentation](http://cantera.github.io/docs/sphinx/html/cython/index.html#sec-cython-documentation)*, documentation of the Python classes and their methods can be accessed from within the Python interpreter as well.\n",
+    "\n",
+    "Suppose you have created a Cantera object and want to know what methads are avialable for it, and get help on using the methods:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "g = ct.Solution('gri30.xml')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To get help on the Python class that this object is an instance of:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Help on Solution in module cantera.composite object:\n",
+      "\n",
+      "class Solution(cantera._cantera.ThermoPhase, cantera._cantera.Kinetics, cantera._cantera.Transport)\n",
+      " |  A class for chemically-reacting solutions. Instances can be created to\n",
+      " |  represent any type of solution -- a mixture of gases, a liquid solution, or\n",
+      " |  a solid solution, for example.\n",
+      " |  \n",
+      " |  Class `Solution` derives from classes `ThermoPhase`, `Kinetics`, and\n",
+      " |  `Transport`.  It defines no methods of its own, and is provided so that a\n",
+      " |  single object can be used to compute thermodynamic, kinetic, and transport\n",
+      " |  properties of a solution.\n",
+      " |  \n",
+      " |  To skip initialization of the Transport object, pass the keyword argument\n",
+      " |  ``transport_model=None`` to the `Solution` constructor.\n",
+      " |  \n",
+      " |  The most common way to instantiate `Solution` objects is by using a phase\n",
+      " |  definition, species and reactions defined in an input file::\n",
+      " |  \n",
+      " |      gas = ct.Solution('gri30.cti')\n",
+      " |  \n",
+      " |  If an input file defines multiple phases, the phase *name* (in CTI) or *id*\n",
+      " |  (in XML) can be used to specify the desired phase::\n",
+      " |  \n",
+      " |      gas = ct.Solution('diamond.cti', 'gas')\n",
+      " |      diamond = ct.Solution('diamond.cti', 'diamond')\n",
+      " |  \n",
+      " |  `Solution` objects can also be constructed using `Species` and `Reaction`\n",
+      " |  objects which can themselves either be imported from input files or defined\n",
+      " |  directly in Python::\n",
+      " |  \n",
+      " |      spec = ct.Species.listFromFile('gri30.cti')\n",
+      " |      rxns = ct.Reaction.listFromFile('gri30.cti')\n",
+      " |      gas = ct.Solution(thermo='IdealGas', kinetics='GasKinetics',\n",
+      " |                        species=spec, reactions=rxns)\n",
+      " |  \n",
+      " |  where the ``thermo`` and ``kinetics`` keyword arguments are strings\n",
+      " |  specifying the thermodynamic and kinetics model, respectively, and\n",
+      " |  ``species`` and ``reactions`` keyword arguments are lists of `Species` and\n",
+      " |  `Reaction` objects, respectively.\n",
+      " |  \n",
+      " |  For non-trivial uses cases of this functionality, see the examples\n",
+      " |  :ref:`py-example-extract_submechanism.py` and\n",
+      " |  :ref:`py-example-mechanism_reduction.py`.\n",
+      " |  \n",
+      " |  In addition, `Solution` objects can be constructed by passing the text of\n",
+      " |  the CTI or XML phase definition in directly, using the ``source`` keyword\n",
+      " |  argument::\n",
+      " |  \n",
+      " |      cti_def = '''\n",
+      " |          ideal_gas(name='gas', elements='O H Ar',\n",
+      " |                    species='gri30: all',\n",
+      " |                    reactions='gri30: all',\n",
+      " |                    options=['skip_undeclared_elements', 'skip_undeclared_species', 'skip_undeclared_third_bodies'],\n",
+      " |                    initial_state=state(temperature=300, pressure=101325))'''\n",
+      " |      gas = ct.Solution(source=cti_def)\n",
+      " |  \n",
+      " |  Method resolution order:\n",
+      " |      Solution\n",
+      " |      cantera._cantera.ThermoPhase\n",
+      " |      cantera._cantera.Kinetics\n",
+      " |      cantera._cantera.Transport\n",
+      " |      cantera._cantera._SolutionBase\n",
+      " |      builtins.object\n",
+      " |  \n",
+      " |  Methods inherited from cantera._cantera.ThermoPhase:\n",
+      " |  \n",
+      " |  __call__(self, /, *args, **kwargs)\n",
+      " |      Call self as a function.\n",
+      " |  \n",
+      " |  __init__(self, /, *args, **kwargs)\n",
+      " |      Initialize self.  See help(type(self)) for accurate signature.\n",
+      " |  \n",
+      " |  __new__(*args, **kwargs) from builtins.type\n",
+      " |      Create and return a new object.  See help(type) for accurate signature.\n",
+      " |  \n",
+      " |  add_species(...)\n",
+      " |      ThermoPhase.add_species(self, Species species)\n",
+      " |      \n",
+      " |      Add a new species to this phase. Missing elements will be added\n",
+      " |      automatically.\n",
+      " |  \n",
+      " |  atomic_weight(...)\n",
+      " |      ThermoPhase.atomic_weight(self, m)\n",
+      " |      Atomic weight [kg/kmol] of element *m*\n",
+      " |  \n",
+      " |  element_index(...)\n",
+      " |      ThermoPhase.element_index(self, element) -> int\n",
+      " |      \n",
+      " |      The index of element *element*, which may be specified as a string or\n",
+      " |      an integer. In the latter case, the index is checked for validity and\n",
+      " |      returned. If no such element is present, an exception is thrown.\n",
+      " |  \n",
+      " |  element_name(...)\n",
+      " |      ThermoPhase.element_name(self, m)\n",
+      " |      Name of the element with index *m*.\n",
+      " |  \n",
+      " |  element_potentials(...)\n",
+      " |      ThermoPhase.element_potentials(self)\n",
+      " |      \n",
+      " |      Get the array of element potentials. The element potentials are only\n",
+      " |      defined for equilibrium states. This method first sets the composition\n",
+      " |      to a state of equilibrium at constant T and P, then computes the\n",
+      " |      element potentials for this equilibrium state.\n",
+      " |  \n",
+      " |  elemental_mass_fraction(...)\n",
+      " |      ThermoPhase.elemental_mass_fraction(self, m)\n",
+      " |      \n",
+      " |      Get the elemental mass fraction :math:`Z_{\\mathrm{mass},m}` of element\n",
+      " |      :math:`m` as defined by:\n",
+      " |      \n",
+      " |      .. math:: Z_{\\mathrm{mass},m} = \\sum_k \\frac{a_{m,k} M_m}{M_k} Y_k\n",
+      " |      \n",
+      " |      with :math:`a_{m,k}` being the number of atoms of element :math:`m` in\n",
+      " |      species :math:`k`, :math:`M_m` the atomic weight of element :math:`m`,\n",
+      " |      :math:`M_k` the molecular weight of species :math:`k`, and :math:`Y_k`\n",
+      " |      the mass fraction of species :math:`k`.\n",
+      " |      \n",
+      " |      :param m:\n",
+      " |          Base element, may be specified by name or by index.\n",
+      " |      \n",
+      " |      >>> phase.elemental_mass_fraction('H')\n",
+      " |      1.0\n",
+      " |  \n",
+      " |  elemental_mole_fraction(...)\n",
+      " |      ThermoPhase.elemental_mole_fraction(self, m)\n",
+      " |      \n",
+      " |      Get the elemental mole fraction :math:`Z_{\\mathrm{mole},m}` of element\n",
+      " |      :math:`m` (the number of atoms of element m divided by the total number\n",
+      " |      of atoms) as defined by:\n",
+      " |      \n",
+      " |      .. math:: Z_{\\mathrm{mole},m} = \\frac{\\sum_k a_{m,k} X_k}\n",
+      " |                                           {\\sum_k \\sum_j a_{j,k} X_k}\n",
+      " |      \n",
+      " |      with :math:`a_{m,k}` being the number of atoms of element :math:`m` in\n",
+      " |      species :math:`k`, :math:`\\sum_j` being a sum over all elements, and\n",
+      " |      :math:`X_k` being the mole fraction of species :math:`k`.\n",
+      " |      \n",
+      " |      :param m:\n",
+      " |          Base element, may be specified by name or by index.\n",
+      " |      \n",
+      " |      >>> phase.elemental_mole_fraction('H')\n",
+      " |      1.0\n",
+      " |  \n",
+      " |  equilibrate(...)\n",
+      " |      ThermoPhase.equilibrate(self, XY, solver='auto', double rtol=1e-09, int maxsteps=1000, int maxiter=100, int estimate_equil=0, int loglevel=0)\n",
+      " |      \n",
+      " |      Set to a state of chemical equilibrium holding property pair\n",
+      " |      *XY* constant.\n",
+      " |      \n",
+      " |      :param XY:\n",
+      " |          A two-letter string, which must be one of the set::\n",
+      " |      \n",
+      " |              ['TP','TV','HP','SP','SV','UV']\n",
+      " |      \n",
+      " |      :param solver:\n",
+      " |          Specifies the equilibrium solver to use. May be one of the following:\n",
+      " |      \n",
+      " |          * ''element_potential'' - a fast solver using the element potential\n",
+      " |            method\n",
+      " |          * 'gibbs' - a slower but more robust Gibbs minimization solver\n",
+      " |          * 'vcs' - the VCS non-ideal equilibrium solver\n",
+      " |          * \"auto\" - The element potential solver will be tried first, then\n",
+      " |            if it fails the Gibbs solver will be tried.\n",
+      " |      :param rtol:\n",
+      " |          the relative error tolerance.\n",
+      " |      :param maxsteps:\n",
+      " |          maximum number of steps in composition to take to find a converged\n",
+      " |          solution.\n",
+      " |      :param maxiter:\n",
+      " |          For the Gibbs minimization solver, this specifies the number of\n",
+      " |          'outer' iterations on T or P when some property pair other\n",
+      " |          than TP is specified.\n",
+      " |      :param estimate_equil:\n",
+      " |          Integer indicating whether the solver should estimate its own\n",
+      " |          initial condition. If 0, the initial mole fraction vector in the\n",
+      " |          ThermoPhase object is used as the initial condition. If 1, the\n",
+      " |          initial mole fraction vector is used if the element abundances are\n",
+      " |          satisfied. If -1, the initial mole fraction vector is thrown out,\n",
+      " |          and an estimate is formulated.\n",
+      " |      :param loglevel:\n",
+      " |          Set to a value > 0 to write diagnostic output.\n",
+      " |  \n",
+      " |  mass_fraction_dict(...)\n",
+      " |      ThermoPhase.mass_fraction_dict(self, double threshold=0.0)\n",
+      " |  \n",
+      " |  modify_species(...)\n",
+      " |      ThermoPhase.modify_species(self, k, Species species)\n",
+      " |  \n",
+      " |  mole_fraction_dict(...)\n",
+      " |      ThermoPhase.mole_fraction_dict(self, double threshold=0.0)\n",
+      " |  \n",
+      " |  n_atoms(...)\n",
+      " |      ThermoPhase.n_atoms(self, species, element)\n",
+      " |      \n",
+      " |      Number of atoms of element *element* in species *species*. The element\n",
+      " |      and species may be specified by name or by index.\n",
+      " |      \n",
+      " |      >>> phase.n_atoms('CH4','H')\n",
+      " |      4\n",
+      " |  \n",
+      " |  report(...)\n",
+      " |      ThermoPhase.report(self, show_thermo=True, float threshold=1e-14)\n",
+      " |      \n",
+      " |      Generate a report describing the thermodynamic state of this phase. To\n",
+      " |      print the report to the terminal, simply call the phase object. The\n",
+      " |      following two statements are equivalent::\n",
+      " |      \n",
+      " |      >>> phase()\n",
+      " |      >>> print(phase.report())\n",
+      " |  \n",
+      " |  set_equivalence_ratio(...)\n",
+      " |      ThermoPhase.set_equivalence_ratio(self, phi, fuel, oxidizer)\n",
+      " |      \n",
+      " |      Set the composition to a mixture of *fuel* and *oxidizer* at the\n",
+      " |      specified equivalence ratio *phi*, holding temperature and pressure\n",
+      " |      constant. Considers the oxidation of C and H to CO2 and H2O. Other\n",
+      " |      elements are assumed not to participate in oxidation (i.e. N ends up as\n",
+      " |      N2)::\n",
+      " |      \n",
+      " |          >>> gas.set_equivalence_ratio(0.5, 'CH4', 'O2:1.0, N2:3.76')\n",
+      " |          >>> gas.mole_fraction_dict()\n",
+      " |          {'CH4': 0.049900199, 'N2': 0.750499001, 'O2': 0.199600798}\n",
+      " |      \n",
+      " |          >>> gas.set_equivalence_ratio(1.2, {'NH3;:0.8, 'CO':0.2}, 'O2:1.0')\n",
+      " |          >>> gas.mole_fraction_dict()\n",
+      " |          {'CO': 0.1263157894, 'NH3': 0.505263157, 'O2': 0.36842105}\n",
+      " |      \n",
+      " |      :param phi: Equivalence ratio\n",
+      " |      :param fuel:\n",
+      " |          Fuel species name or molar composition as string, array, or dict.\n",
+      " |      :param oxidizer:\n",
+      " |          Oxidizer species name or molar composition as a string, array, or\n",
+      " |          dict.\n",
+      " |  \n",
+      " |  set_unnormalized_mass_fractions(...)\n",
+      " |      ThermoPhase.set_unnormalized_mass_fractions(self, Y)\n",
+      " |      \n",
+      " |      Set the mass fractions without normalizing to force sum(Y) == 1.0.\n",
+      " |      Useful primarily when calculating derivatives with respect to Y[k] by\n",
+      " |      finite difference.\n",
+      " |  \n",
+      " |  set_unnormalized_mole_fractions(...)\n",
+      " |      ThermoPhase.set_unnormalized_mole_fractions(self, X)\n",
+      " |      \n",
+      " |      Set the mole fractions without normalizing to force sum(X) == 1.0.\n",
+      " |      Useful primarily when calculating derivatives with respect to X[k]\n",
+      " |      by finite difference.\n",
+      " |  \n",
+      " |  species(...)\n",
+      " |      ThermoPhase.species(self, k=None)\n",
+      " |      \n",
+      " |      Return the `Species` object for species *k*, where *k* is either the\n",
+      " |      species index or the species name. If *k* is not specified, a list of\n",
+      " |      all species objects is returned.\n",
+      " |  \n",
+      " |  species_index(...)\n",
+      " |      ThermoPhase.species_index(self, species) -> int\n",
+      " |      \n",
+      " |      The index of species *species*, which may be specified as a string or\n",
+      " |      an integer. In the latter case, the index is checked for validity and\n",
+      " |      returned. If no such species is present, an exception is thrown.\n",
+      " |  \n",
+      " |  species_name(...)\n",
+      " |      ThermoPhase.species_name(self, k)\n",
+      " |      Name of the species with index *k*.\n",
+      " |  \n",
+      " |  ----------------------------------------------------------------------\n",
+      " |  Data descriptors inherited from cantera._cantera.ThermoPhase:\n",
+      " |  \n",
+      " |  DP\n",
+      " |      Get/Set density [kg/m^3] and pressure [Pa].\n",
+      " |  \n",
+      " |  DPX\n",
+      " |      Get/Set density [kg/m^3], pressure [Pa], and mole fractions.\n",
+      " |  \n",
+      " |  DPY\n",
+      " |      Get/Set density [kg/m^3], pressure [Pa], and mass fractions.\n",
+      " |  \n",
+      " |  HP\n",
+      " |      Get/Set enthalpy [J/kg or J/kmol] and pressure [Pa].\n",
+      " |  \n",
+      " |  HPX\n",
+      " |      Get/Set enthalpy [J/kg or J/kmol], pressure [Pa] and mole fractions.\n",
+      " |  \n",
+      " |  HPY\n",
+      " |      Get/Set enthalpy [J/kg or J/kmol], pressure [Pa] and mass fractions.\n",
+      " |  \n",
+      " |  ID\n",
+      " |      The ID of the phase. The default is taken from the CTI/XML input file.\n",
+      " |  \n",
+      " |  P\n",
+      " |      Pressure [Pa].\n",
+      " |  \n",
+      " |  P_sat\n",
+      " |      Saturation pressure [Pa] at the current temperature.\n",
+      " |  \n",
+      " |  SP\n",
+      " |      Get/Set entropy [J/kg/K or J/kmol/K] and pressure [Pa].\n",
+      " |  \n",
+      " |  SPX\n",
+      " |      Get/Set entropy [J/kg/K or J/kmol/K], pressure [Pa], and mole fractions.\n",
+      " |  \n",
+      " |  SPY\n",
+      " |      Get/Set entropy [J/kg/K or J/kmol/K], pressure [Pa], and mass fractions.\n",
+      " |  \n",
+      " |  SV\n",
+      " |      Get/Set entropy [J/kg/K or J/kmol/K] and specific volume [m^3/kg or\n",
+      " |      m^3/kmol].\n",
+      " |  \n",
+      " |  SVX\n",
+      " |      Get/Set entropy [J/kg/K or J/kmol/K], specific volume [m^3/kg or\n",
+      " |      m^3/kmol], and mole fractions.\n",
+      " |  \n",
+      " |  SVY\n",
+      " |      Get/Set entropy [J/kg/K or J/kmol/K], specific volume [m^3/kg or\n",
+      " |      m^3/kmol], and mass fractions.\n",
+      " |  \n",
+      " |  T\n",
+      " |      Temperature [K].\n",
+      " |  \n",
+      " |  TD\n",
+      " |      Get/Set temperature [K] and density [kg/m^3 or kmol/m^3].\n",
+      " |  \n",
+      " |  TDX\n",
+      " |      Get/Set temperature [K], density [kg/m^3 or kmol/m^3], and mole\n",
+      " |      fractions.\n",
+      " |  \n",
+      " |  TDY\n",
+      " |      Get/Set temperature [K] and density [kg/m^3 or kmol/m^3], and mass\n",
+      " |      fractions.\n",
+      " |  \n",
+      " |  TP\n",
+      " |      Get/Set temperature [K] and pressure [Pa].\n",
+      " |  \n",
+      " |  TPX\n",
+      " |      Get/Set temperature [K], pressure [Pa], and mole fractions.\n",
+      " |  \n",
+      " |  TPY\n",
+      " |      Get/Set temperature [K], pressure [Pa], and mass fractions.\n",
+      " |  \n",
+      " |  T_sat\n",
+      " |      Saturation temperature [K] at the current pressure.\n",
+      " |  \n",
+      " |  UV\n",
+      " |      Get/Set internal energy [J/kg or J/kmol] and specific volume\n",
+      " |      [m^3/kg or m^3/kmol].\n",
+      " |  \n",
+      " |  UVX\n",
+      " |      Get/Set internal energy [J/kg or J/kmol], specific volume\n",
+      " |      [m^3/kg or m^3/kmol], and mole fractions.\n",
+      " |  \n",
+      " |  UVY\n",
+      " |      Get/Set internal energy [J/kg or J/kmol], specific volume\n",
+      " |      [m^3/kg or m^3/kmol], and mass fractions.\n",
+      " |  \n",
+      " |  X\n",
+      " |      Get/Set the species mole fractions. Can be set as an array, as a dictionary,\n",
+      " |      or as a string. Always returns an array::\n",
+      " |      \n",
+      " |          >>> phase.X = [0.1, 0, 0, 0.4, 0, 0, 0, 0, 0.5]\n",
+      " |          >>> phase.X = {'H2':0.1, 'O2':0.4, 'AR':0.5}\n",
+      " |          >>> phase.X = 'H2:0.1, O2:0.4, AR:0.5'\n",
+      " |          >>> phase.X\n",
+      " |          array([0.1, 0, 0, 0.4, 0, 0, 0, 0, 0.5])\n",
+      " |  \n",
+      " |  Y\n",
+      " |      Get/Set the species mass fractions. Can be set as an array, as a dictionary,\n",
+      " |      or as a string. Always returns an array::\n",
+      " |      \n",
+      " |          >>> phase.Y = [0.1, 0, 0, 0.4, 0, 0, 0, 0, 0.5]\n",
+      " |          >>> phase.Y = {'H2':0.1, 'O2':0.4, 'AR':0.5}\n",
+      " |          >>> phase.Y = 'H2:0.1, O2:0.4, AR:0.5'\n",
+      " |          >>> phase.Y\n",
+      " |          array([0.1, 0, 0, 0.4, 0, 0, 0, 0, 0.5])\n",
+      " |  \n",
+      " |  atomic_weights\n",
+      " |      Array of atomic weight [kg/kmol] for each element in the mixture.\n",
+      " |  \n",
+      " |  basis\n",
+      " |      Determines whether intensive thermodynamic properties are treated on a\n",
+      " |      `mass` (per kg) or `molar` (per kmol) basis. This affects the values\n",
+      " |      returned by the properties `h`, `u`, `s`, `g`, `v`, `density`, `cv`,\n",
+      " |      and `cp`, as well as the values used with the state-setting properties\n",
+      " |      such as `HPX` and `UV`.\n",
+      " |  \n",
+      " |  chemical_potentials\n",
+      " |      Array of species chemical potentials [J/kmol].\n",
+      " |  \n",
+      " |  concentrations\n",
+      " |      Get/Set the species concentrations [kmol/m^3].\n",
+      " |  \n",
+      " |  cp\n",
+      " |      Heat capacity at constant pressure [J/kg/K or J/kmol/K] depending\n",
+      " |      on `basis`.\n",
+      " |  \n",
+      " |  cp_mass\n",
+      " |      Specific heat capacity at constant pressure [J/kg/K].\n",
+      " |  \n",
+      " |  cp_mole\n",
+      " |      Molar heat capacity at constant pressure [J/kmol/K].\n",
+      " |  \n",
+      " |  critical_density\n",
+      " |      Critical density [kg/m^3 or kmol/m^3] depending on `basis`.\n",
+      " |  \n",
+      " |  critical_pressure\n",
+      " |      Critical pressure [Pa].\n",
+      " |  \n",
+      " |  critical_temperature\n",
+      " |      Critical temperature [K].\n",
+      " |  \n",
+      " |  cv\n",
+      " |      Heat capacity at constant volume [J/kg/K or J/kmol/K] depending on\n",
+      " |      `basis`.\n",
+      " |  \n",
+      " |  cv_mass\n",
+      " |      Specific heat capacity at constant volume [J/kg/K].\n",
+      " |  \n",
+      " |  cv_mole\n",
+      " |      Molar heat capacity at constant volume [J/kmol/K].\n",
+      " |  \n",
+      " |  density\n",
+      " |      Density [kg/m^3 or kmol/m^3] depending on `basis`.\n",
+      " |  \n",
+      " |  density_mass\n",
+      " |      (Mass) density [kg/m^3].\n",
+      " |  \n",
+      " |  density_mole\n",
+      " |      Molar density [kmol/m^3].\n",
+      " |  \n",
+      " |  electric_potential\n",
+      " |      Get/Set the electric potential [V] for this phase.\n",
+      " |  \n",
+      " |  electrochemical_potentials\n",
+      " |      Array of species electrochemical potentials [J/kmol].\n",
+      " |  \n",
+      " |  element_names\n",
+      " |      A list of all the element names.\n",
+      " |  \n",
+      " |  enthalpy_mass\n",
+      " |      Specific enthalpy [J/kg].\n",
+      " |  \n",
+      " |  enthalpy_mole\n",
+      " |      Molar enthalpy [J/kmol].\n",
+      " |  \n",
+      " |  entropy_mass\n",
+      " |      Specific entropy [J/kg].\n",
+      " |  \n",
+      " |  entropy_mole\n",
+      " |      Molar entropy [J/kmol/K].\n",
+      " |  \n",
+      " |  g\n",
+      " |      Gibbs free energy [J/kg or J/kmol] depending on `basis`.\n",
+      " |  \n",
+      " |  gibbs_mass\n",
+      " |      Specific Gibbs free energy [J/kg].\n",
+      " |  \n",
+      " |  gibbs_mole\n",
+      " |      Molar Gibbs free energy [J/kmol].\n",
+      " |  \n",
+      " |  h\n",
+      " |      Enthalpy [J/kg or J/kmol] depending on `basis`.\n",
+      " |  \n",
+      " |  int_energy_mass\n",
+      " |      Specific internal energy [J/kg].\n",
+      " |  \n",
+      " |  int_energy_mole\n",
+      " |      Molar internal energy [J/kmol].\n",
+      " |  \n",
+      " |  isothermal_compressibility\n",
+      " |      Isothermal compressibility [1/Pa].\n",
+      " |  \n",
+      " |  max_temp\n",
+      " |      Maximum temperature for which the thermodynamic data for the phase are\n",
+      " |      valid.\n",
+      " |  \n",
+      " |  mean_molecular_weight\n",
+      " |      The mean molecular weight (molar mass) [kg/kmol].\n",
+      " |  \n",
+      " |  min_temp\n",
+      " |      Minimum temperature for which the thermodynamic data for the phase are\n",
+      " |      valid.\n",
+      " |  \n",
+      " |  molecular_weights\n",
+      " |      Array of species molecular weights (molar masses) [kg/kmol].\n",
+      " |  \n",
+      " |  n_elements\n",
+      " |      Number of elements.\n",
+      " |  \n",
+      " |  n_selected_species\n",
+      " |      Number of species selected for output (by slicing of Solution object)\n",
+      " |  \n",
+      " |  n_species\n",
+      " |      Number of species.\n",
+      " |  \n",
+      " |  name\n",
+      " |      The name assigned to this phase. The default is taken from the CTI/XML\n",
+      " |      input file.\n",
+      " |  \n",
+      " |  partial_molar_cp\n",
+      " |      Array of species partial molar specific heat capacities at constant\n",
+      " |      pressure [J/kmol/K].\n",
+      " |  \n",
+      " |  partial_molar_enthalpies\n",
+      " |      Array of species partial molar enthalpies [J/kmol].\n",
+      " |  \n",
+      " |  partial_molar_entropies\n",
+      " |      Array of species partial molar entropies [J/kmol/K].\n",
+      " |  \n",
+      " |  partial_molar_int_energies\n",
+      " |      Array of species partial molar internal energies [J/kmol].\n",
+      " |  \n",
+      " |  partial_molar_volumes\n",
+      " |      Array of species partial molar volumes [m^3/kmol].\n",
+      " |  \n",
+      " |  reference_pressure\n",
+      " |      Reference state pressure [Pa].\n",
+      " |  \n",
+      " |  s\n",
+      " |      Entropy [J/kg/K or J/kmol/K] depending on `basis`.\n",
+      " |  \n",
+      " |  species_names\n",
+      " |      A list of all the species names.\n",
+      " |  \n",
+      " |  standard_cp_R\n",
+      " |      Array of nondimensional species standard-state specific heat capacities\n",
+      " |      at constant pressure at the current temperature and pressure.\n",
+      " |  \n",
+      " |  standard_enthalpies_RT\n",
+      " |      Array of nondimensional species standard-state enthalpies at the\n",
+      " |      current temperature and pressure.\n",
+      " |  \n",
+      " |  standard_entropies_R\n",
+      " |      Array of nondimensional species standard-state entropies at the\n",
+      " |      current temperature and pressure.\n",
+      " |  \n",
+      " |  standard_gibbs_RT\n",
+      " |      Array of nondimensional species standard-state Gibbs free energies at\n",
+      " |      the current temperature and pressure.\n",
+      " |  \n",
+      " |  standard_int_energies_RT\n",
+      " |      Array of nondimensional species standard-state internal energies at the\n",
+      " |      current temperature and pressure.\n",
+      " |  \n",
+      " |  state\n",
+      " |      Get/Set the full thermodynamic state as a single array, arranged as\n",
+      " |      [temperature, density, mass fractions] for most phases. Useful mainly\n",
+      " |      in cases where it is desired to store many states in a multidimensional\n",
+      " |      array.\n",
+      " |  \n",
+      " |  thermal_expansion_coeff\n",
+      " |      Thermal expansion coefficient [1/K].\n",
+      " |  \n",
+      " |  u\n",
+      " |      Internal energy in [J/kg or J/kmol].\n",
+      " |  \n",
+      " |  v\n",
+      " |      Specific volume [m^3/kg or m^3/kmol] depending on `basis`.\n",
+      " |  \n",
+      " |  volume_mass\n",
+      " |      Specific volume [m^3/kg].\n",
+      " |  \n",
+      " |  volume_mole\n",
+      " |      Molar volume [m^3/kmol].\n",
+      " |  \n",
+      " |  ----------------------------------------------------------------------\n",
+      " |  Data and other attributes inherited from cantera._cantera.ThermoPhase:\n",
+      " |  \n",
+      " |  __pyx_vtable__ = <capsule object NULL>\n",
+      " |  \n",
+      " |  ----------------------------------------------------------------------\n",
+      " |  Methods inherited from cantera._cantera.Kinetics:\n",
+      " |  \n",
+      " |  add_reaction(...)\n",
+      " |      Kinetics.add_reaction(self, Reaction rxn)\n",
+      " |      Add a new reaction to this phase.\n",
+      " |  \n",
+      " |  is_reversible(...)\n",
+      " |      Kinetics.is_reversible(self, int i_reaction)\n",
+      " |      True if reaction `i_reaction` is reversible.\n",
+      " |  \n",
+      " |  kinetics_species_index(...)\n",
+      " |      Kinetics.kinetics_species_index(self, species, int phase=0)\n",
+      " |      \n",
+      " |      The index of species *species* of phase *phase* within arrays returned\n",
+      " |      by methods of class `Kinetics`. If *species* is a string, the *phase*\n",
+      " |      argument is unused.\n",
+      " |  \n",
+      " |  modify_reaction(...)\n",
+      " |      Kinetics.modify_reaction(self, int irxn, Reaction rxn)\n",
+      " |      \n",
+      " |      Modify the `Reaction` with index ``irxn`` to have the same rate\n",
+      " |      parameters as ``rxn``. ``rxn`` must have the same reactants and products\n",
+      " |      and be of the same type (i.e. `ElementaryReaction`, `FalloffReaction`,\n",
+      " |      `PlogReaction`, etc.) as the existing reaction. This method does not\n",
+      " |      modify the third-body efficiencies, reaction orders, or reversibility of\n",
+      " |      the reaction.\n",
+      " |  \n",
+      " |  multiplier(...)\n",
+      " |      Kinetics.multiplier(self, int i_reaction)\n",
+      " |      \n",
+      " |      A scaling factor applied to the rate coefficient for reaction\n",
+      " |      *i_reaction*. Can be used to carry out sensitivity analysis or to\n",
+      " |      selectively disable a particular reaction. See `set_multiplier`.\n",
+      " |  \n",
+      " |  product_stoich_coeff(...)\n",
+      " |      Kinetics.product_stoich_coeff(self, k_spec, int i_reaction)\n",
+      " |      \n",
+      " |      The stoichiometric coefficient of species *k_spec* as a product in\n",
+      " |      reaction *i_reaction*.\n",
+      " |  \n",
+      " |  product_stoich_coeffs(...)\n",
+      " |      Kinetics.product_stoich_coeffs(self)\n",
+      " |      \n",
+      " |      The array of product stoichiometric coefficients. Element *[k,i]* of\n",
+      " |      this array is the product stoichiometric coefficient of species *k* in\n",
+      " |      reaction *i*.\n",
+      " |  \n",
+      " |  products(...)\n",
+      " |      Kinetics.products(self, int i_reaction)\n",
+      " |      The products portion of the reaction equation\n",
+      " |  \n",
+      " |  reactant_stoich_coeff(...)\n",
+      " |      Kinetics.reactant_stoich_coeff(self, k_spec, int i_reaction)\n",
+      " |      \n",
+      " |      The stoichiometric coefficient of species *k_spec* as a reactant in\n",
+      " |      reaction *i_reaction*.\n",
+      " |  \n",
+      " |  reactant_stoich_coeffs(...)\n",
+      " |      Kinetics.reactant_stoich_coeffs(self)\n",
+      " |      \n",
+      " |      The array of reactant stoichiometric coefficients. Element *[k,i]* of\n",
+      " |      this array is the reactant stoichiometric coefficient of species *k* in\n",
+      " |      reaction *i*.\n",
+      " |  \n",
+      " |  reactants(...)\n",
+      " |      Kinetics.reactants(self, int i_reaction)\n",
+      " |      The reactants portion of the reaction equation\n",
+      " |  \n",
+      " |  reaction(...)\n",
+      " |      Kinetics.reaction(self, int i_reaction)\n",
+      " |      \n",
+      " |      Return a `Reaction` object representing the reaction with index\n",
+      " |      ``i_reaction``.\n",
+      " |  \n",
+      " |  reaction_equation(...)\n",
+      " |      Kinetics.reaction_equation(self, int i_reaction)\n",
+      " |      The equation for the specified reaction. See also `reaction_equations`.\n",
+      " |  \n",
+      " |  reaction_equations(...)\n",
+      " |      Kinetics.reaction_equations(self, indices=None)\n",
+      " |      \n",
+      " |      Returns a list containing the reaction equation for all reactions in the\n",
+      " |      mechanism (if *indices* is unspecified) or the equations for each\n",
+      " |      reaction in the sequence *indices*. For example::\n",
+      " |      \n",
+      " |          >>> gas.reaction_equations()\n",
+      " |          ['2 O + M <=> O2 + M', 'O + H + M <=> OH + M', 'O + H2 <=> H + OH', ...]\n",
+      " |          >>> gas.reaction_equations([2,3])\n",
+      " |          ['O + H + M <=> OH + M', 'O + H2 <=> H + OH']\n",
+      " |      \n",
+      " |      See also `reaction_equation`.\n",
+      " |  \n",
+      " |  reaction_type(...)\n",
+      " |      Kinetics.reaction_type(self, int i_reaction)\n",
+      " |      Type of reaction *i_reaction*.\n",
+      " |  \n",
+      " |  reactions(...)\n",
+      " |      Kinetics.reactions(self)\n",
+      " |      \n",
+      " |      Return a list of all `Reaction` objects\n",
+      " |  \n",
+      " |  set_multiplier(...)\n",
+      " |      Kinetics.set_multiplier(self, double value, int i_reaction=-1)\n",
+      " |      \n",
+      " |      Set the multiplier for for reaction *i_reaction* to *value*.\n",
+      " |      If *i_reaction* is not specified, then the multiplier for all reactions\n",
+      " |      is set to *value*. See `multiplier`.\n",
+      " |  \n",
+      " |  ----------------------------------------------------------------------\n",
+      " |  Data descriptors inherited from cantera._cantera.Kinetics:\n",
+      " |  \n",
+      " |  creation_rates\n",
+      " |      Creation rates for each species. [kmol/m^3/s] for bulk phases or\n",
+      " |      [kmol/m^2/s] for surface phases.\n",
+      " |  \n",
+      " |  delta_enthalpy\n",
+      " |      Change in enthalpy for each reaction [J/kmol].\n",
+      " |  \n",
+      " |  delta_entropy\n",
+      " |      Change in entropy for each reaction [J/kmol/K].\n",
+      " |  \n",
+      " |  delta_gibbs\n",
+      " |      Change in Gibbs free energy for each reaction [J/kmol].\n",
+      " |  \n",
+      " |  delta_standard_enthalpy\n",
+      " |      Change in standard-state enthalpy (independent of composition) for\n",
+      " |      each reaction [J/kmol].\n",
+      " |  \n",
+      " |  delta_standard_entropy\n",
+      " |      Change in standard-state entropy (independent of composition) for\n",
+      " |      each reaction [J/kmol/K].\n",
+      " |  \n",
+      " |  delta_standard_gibbs\n",
+      " |      Change in standard-state Gibbs free energy (independent of composition)\n",
+      " |      for each reaction [J/kmol].\n",
+      " |  \n",
+      " |  destruction_rates\n",
+      " |      Destruction rates for each species. [kmol/m^3/s] for bulk phases or\n",
+      " |      [kmol/m^2/s] for surface phases.\n",
+      " |  \n",
+      " |  equilibrium_constants\n",
+      " |      Equilibrium constants in concentration units for all reactions.\n",
+      " |  \n",
+      " |  forward_rate_constants\n",
+      " |      Forward rate constants for all reactions. Units are a combination of\n",
+      " |      kmol, m^3 and s, that depend on the rate expression for the reaction.\n",
+      " |  \n",
+      " |  forward_rates_of_progress\n",
+      " |      Forward rates of progress for the reactions. [kmol/m^3/s] for bulk\n",
+      " |      phases or [kmol/m^2/s] for surface phases.\n",
+      " |  \n",
+      " |  n_phases\n",
+      " |      Number of phases in the reaction mechanism.\n",
+      " |  \n",
+      " |  n_reactions\n",
+      " |      Number of reactions in the reaction mechanism.\n",
+      " |  \n",
+      " |  n_total_species\n",
+      " |      Total number of species in all phases participating in the kinetics\n",
+      " |      mechanism.\n",
+      " |  \n",
+      " |  net_production_rates\n",
+      " |      Net production rates for each species. [kmol/m^3/s] for bulk phases or\n",
+      " |      [kmol/m^2/s] for surface phases.\n",
+      " |  \n",
+      " |  net_rates_of_progress\n",
+      " |      Net rates of progress for the reactions. [kmol/m^3/s] for bulk phases\n",
+      " |      or [kmol/m^2/s] for surface phases.\n",
+      " |  \n",
+      " |  reaction_phase_index\n",
+      " |      The index of the phase where the reactions occur.\n",
+      " |  \n",
+      " |  reverse_rate_constants\n",
+      " |      Reverse rate constants for all reactions. Units are a combination of\n",
+      " |      kmol, m^3 and s, that depend on the rate expression for the reaction.\n",
+      " |  \n",
+      " |  reverse_rates_of_progress\n",
+      " |      Reverse rates of progress for the reactions. [kmol/m^3/s] for bulk\n",
+      " |      phases or [kmol/m^2/s] for surface phases.\n",
+      " |  \n",
+      " |  ----------------------------------------------------------------------\n",
+      " |  Data descriptors inherited from cantera._cantera.Transport:\n",
+      " |  \n",
+      " |  binary_diff_coeffs\n",
+      " |      Binary diffusion coefficients [m^2/s].\n",
+      " |  \n",
+      " |  electrical_conductivity\n",
+      " |      Electrical conductivity. [S/m].\n",
+      " |  \n",
+      " |  mix_diff_coeffs\n",
+      " |      Mixture-averaged diffusion coefficients [m^2/s] relating the\n",
+      " |      mass-averaged diffusive fluxes (with respect to the mass averaged\n",
+      " |      velocity) to gradients in the species mole fractions.\n",
+      " |  \n",
+      " |  mix_diff_coeffs_mass\n",
+      " |      Mixture-averaged diffusion coefficients [m^2/s] relating the\n",
+      " |      diffusive mass fluxes to gradients in the species mass fractions.\n",
+      " |  \n",
+      " |  mix_diff_coeffs_mole\n",
+      " |      Mixture-averaged diffusion coefficients [m^2/s] relating the\n",
+      " |      molar diffusive fluxes to gradients in the species mole fractions.\n",
+      " |  \n",
+      " |  multi_diff_coeffs\n",
+      " |      Multicomponent diffusion coefficients [m^2/s].\n",
+      " |  \n",
+      " |  thermal_conductivity\n",
+      " |      Thermal conductivity. [W/m/K].\n",
+      " |  \n",
+      " |  thermal_diff_coeffs\n",
+      " |      Return a one-dimensional array of the species thermal diffusion\n",
+      " |      coefficients [kg/m/s].\n",
+      " |  \n",
+      " |  transport_model\n",
+      " |      Get/Set the transport model associated with this transport model.\n",
+      " |      \n",
+      " |      Setting a new transport model deletes the underlying C++ Transport\n",
+      " |      object and replaces it with a new one implementing the specified model.\n",
+      " |  \n",
+      " |  viscosity\n",
+      " |      Viscosity [Pa-s].\n",
+      " |  \n",
+      " |  ----------------------------------------------------------------------\n",
+      " |  Methods inherited from cantera._cantera._SolutionBase:\n",
+      " |  \n",
+      " |  __copy__(...)\n",
+      " |      _SolutionBase.__copy__(self)\n",
+      " |  \n",
+      " |  __getitem__(self, key, /)\n",
+      " |      Return self[key].\n",
+      " |  \n",
+      " |  __reduce__(...)\n",
+      " |      _SolutionBase.__reduce__(self)\n",
+      " |  \n",
+      " |  ----------------------------------------------------------------------\n",
+      " |  Data descriptors inherited from cantera._cantera._SolutionBase:\n",
+      " |  \n",
+      " |  selected_species\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "help(g)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For a simple list of the properties and methods of this object:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['DP',\n",
+       " 'DPX',\n",
+       " 'DPY',\n",
+       " 'HP',\n",
+       " 'HPX',\n",
+       " 'HPY',\n",
+       " 'ID',\n",
+       " 'P',\n",
+       " 'P_sat',\n",
+       " 'SP',\n",
+       " 'SPX',\n",
+       " 'SPY',\n",
+       " 'SV',\n",
+       " 'SVX',\n",
+       " 'SVY',\n",
+       " 'T',\n",
+       " 'TD',\n",
+       " 'TDX',\n",
+       " 'TDY',\n",
+       " 'TP',\n",
+       " 'TPX',\n",
+       " 'TPY',\n",
+       " 'T_sat',\n",
+       " 'UV',\n",
+       " 'UVX',\n",
+       " 'UVY',\n",
+       " 'X',\n",
+       " 'Y',\n",
+       " '__call__',\n",
+       " '__class__',\n",
+       " '__copy__',\n",
+       " '__delattr__',\n",
+       " '__dir__',\n",
+       " '__doc__',\n",
+       " '__eq__',\n",
+       " '__format__',\n",
+       " '__ge__',\n",
+       " '__getattribute__',\n",
+       " '__getitem__',\n",
+       " '__gt__',\n",
+       " '__hash__',\n",
+       " '__init__',\n",
+       " '__init_subclass__',\n",
+       " '__le__',\n",
+       " '__lt__',\n",
+       " '__module__',\n",
+       " '__ne__',\n",
+       " '__new__',\n",
+       " '__pyx_vtable__',\n",
+       " '__reduce__',\n",
+       " '__reduce_ex__',\n",
+       " '__repr__',\n",
+       " '__setattr__',\n",
+       " '__sizeof__',\n",
+       " '__slots__',\n",
+       " '__str__',\n",
+       " '__subclasshook__',\n",
+       " '_check_kinetics_species_index',\n",
+       " '_check_phase_index',\n",
+       " '_check_reaction_index',\n",
+       " '_full_states',\n",
+       " '_init_cti_xml',\n",
+       " '_init_parts',\n",
+       " '_references',\n",
+       " 'add_reaction',\n",
+       " 'add_species',\n",
+       " 'atomic_weight',\n",
+       " 'atomic_weights',\n",
+       " 'basis',\n",
+       " 'binary_diff_coeffs',\n",
+       " 'chemical_potentials',\n",
+       " 'concentrations',\n",
+       " 'cp',\n",
+       " 'cp_mass',\n",
+       " 'cp_mole',\n",
+       " 'creation_rates',\n",
+       " 'critical_density',\n",
+       " 'critical_pressure',\n",
+       " 'critical_temperature',\n",
+       " 'cv',\n",
+       " 'cv_mass',\n",
+       " 'cv_mole',\n",
+       " 'delta_enthalpy',\n",
+       " 'delta_entropy',\n",
+       " 'delta_gibbs',\n",
+       " 'delta_standard_enthalpy',\n",
+       " 'delta_standard_entropy',\n",
+       " 'delta_standard_gibbs',\n",
+       " 'density',\n",
+       " 'density_mass',\n",
+       " 'density_mole',\n",
+       " 'destruction_rates',\n",
+       " 'electric_potential',\n",
+       " 'electrical_conductivity',\n",
+       " 'electrochemical_potentials',\n",
+       " 'element_index',\n",
+       " 'element_name',\n",
+       " 'element_names',\n",
+       " 'element_potentials',\n",
+       " 'elemental_mass_fraction',\n",
+       " 'elemental_mole_fraction',\n",
+       " 'enthalpy_mass',\n",
+       " 'enthalpy_mole',\n",
+       " 'entropy_mass',\n",
+       " 'entropy_mole',\n",
+       " 'equilibrate',\n",
+       " 'equilibrium_constants',\n",
+       " 'forward_rate_constants',\n",
+       " 'forward_rates_of_progress',\n",
+       " 'g',\n",
+       " 'gibbs_mass',\n",
+       " 'gibbs_mole',\n",
+       " 'h',\n",
+       " 'int_energy_mass',\n",
+       " 'int_energy_mole',\n",
+       " 'is_reversible',\n",
+       " 'isothermal_compressibility',\n",
+       " 'kinetics_species_index',\n",
+       " 'mass_fraction_dict',\n",
+       " 'max_temp',\n",
+       " 'mean_molecular_weight',\n",
+       " 'min_temp',\n",
+       " 'mix_diff_coeffs',\n",
+       " 'mix_diff_coeffs_mass',\n",
+       " 'mix_diff_coeffs_mole',\n",
+       " 'modify_reaction',\n",
+       " 'modify_species',\n",
+       " 'mole_fraction_dict',\n",
+       " 'molecular_weights',\n",
+       " 'multi_diff_coeffs',\n",
+       " 'multiplier',\n",
+       " 'n_atoms',\n",
+       " 'n_elements',\n",
+       " 'n_phases',\n",
+       " 'n_reactions',\n",
+       " 'n_selected_species',\n",
+       " 'n_species',\n",
+       " 'n_total_species',\n",
+       " 'name',\n",
+       " 'net_production_rates',\n",
+       " 'net_rates_of_progress',\n",
+       " 'partial_molar_cp',\n",
+       " 'partial_molar_enthalpies',\n",
+       " 'partial_molar_entropies',\n",
+       " 'partial_molar_int_energies',\n",
+       " 'partial_molar_volumes',\n",
+       " 'product_stoich_coeff',\n",
+       " 'product_stoich_coeffs',\n",
+       " 'products',\n",
+       " 'reactant_stoich_coeff',\n",
+       " 'reactant_stoich_coeffs',\n",
+       " 'reactants',\n",
+       " 'reaction',\n",
+       " 'reaction_equation',\n",
+       " 'reaction_equations',\n",
+       " 'reaction_phase_index',\n",
+       " 'reaction_type',\n",
+       " 'reactions',\n",
+       " 'reference_pressure',\n",
+       " 'report',\n",
+       " 'reverse_rate_constants',\n",
+       " 'reverse_rates_of_progress',\n",
+       " 's',\n",
+       " 'selected_species',\n",
+       " 'set_equivalence_ratio',\n",
+       " 'set_multiplier',\n",
+       " 'set_unnormalized_mass_fractions',\n",
+       " 'set_unnormalized_mole_fractions',\n",
+       " 'species',\n",
+       " 'species_index',\n",
+       " 'species_name',\n",
+       " 'species_names',\n",
+       " 'standard_cp_R',\n",
+       " 'standard_enthalpies_RT',\n",
+       " 'standard_entropies_R',\n",
+       " 'standard_gibbs_RT',\n",
+       " 'standard_int_energies_RT',\n",
+       " 'state',\n",
+       " 'thermal_conductivity',\n",
+       " 'thermal_diff_coeffs',\n",
+       " 'thermal_expansion_coeff',\n",
+       " 'transport_model',\n",
+       " 'u',\n",
+       " 'v',\n",
+       " 'viscosity',\n",
+       " 'volume_mass',\n",
+       " 'volume_mole']"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dir(g)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To get help on a specific method, e.g. the `species_index` method:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Help on built-in function species_index:\n",
+      "\n",
+      "species_index(...) method of cantera.composite.Solution instance\n",
+      "    ThermoPhase.species_index(self, species) -> int\n",
+      "    \n",
+      "    The index of species *species*, which may be specified as a string or\n",
+      "    an integer. In the latter case, the index is checked for validity and\n",
+      "    returned. If no such species is present, an exception is thrown.\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "help(g.species_index)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For properties, getting the documentation is slightly trickier, as the usual method will give you help for the *result*, e.g.:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Help on float object:\n",
+      "\n",
+      "class float(object)\n",
+      " |  float(x) -> floating point number\n",
+      " |  \n",
+      " |  Convert a string or number to a floating point number, if possible.\n",
+      " |  \n",
+      " |  Methods defined here:\n",
+      " |  \n",
+      " |  __abs__(self, /)\n",
+      " |      abs(self)\n",
+      " |  \n",
+      " |  __add__(self, value, /)\n",
+      " |      Return self+value.\n",
+      " |  \n",
+      " |  __bool__(self, /)\n",
+      " |      self != 0\n",
+      " |  \n",
+      " |  __divmod__(self, value, /)\n",
+      " |      Return divmod(self, value).\n",
+      " |  \n",
+      " |  __eq__(self, value, /)\n",
+      " |      Return self==value.\n",
+      " |  \n",
+      " |  __float__(self, /)\n",
+      " |      float(self)\n",
+      " |  \n",
+      " |  __floordiv__(self, value, /)\n",
+      " |      Return self//value.\n",
+      " |  \n",
+      " |  __format__(...)\n",
+      " |      float.__format__(format_spec) -> string\n",
+      " |      \n",
+      " |      Formats the float according to format_spec.\n",
+      " |  \n",
+      " |  __ge__(self, value, /)\n",
+      " |      Return self>=value.\n",
+      " |  \n",
+      " |  __getattribute__(self, name, /)\n",
+      " |      Return getattr(self, name).\n",
+      " |  \n",
+      " |  __getformat__(...) from builtins.type\n",
+      " |      float.__getformat__(typestr) -> string\n",
+      " |      \n",
+      " |      You probably don't want to use this function.  It exists mainly to be\n",
+      " |      used in Python's test suite.\n",
+      " |      \n",
+      " |      typestr must be 'double' or 'float'.  This function returns whichever of\n",
+      " |      'unknown', 'IEEE, big-endian' or 'IEEE, little-endian' best describes the\n",
+      " |      format of floating point numbers used by the C type named by typestr.\n",
+      " |  \n",
+      " |  __getnewargs__(...)\n",
+      " |  \n",
+      " |  __gt__(self, value, /)\n",
+      " |      Return self>value.\n",
+      " |  \n",
+      " |  __hash__(self, /)\n",
+      " |      Return hash(self).\n",
+      " |  \n",
+      " |  __int__(self, /)\n",
+      " |      int(self)\n",
+      " |  \n",
+      " |  __le__(self, value, /)\n",
+      " |      Return self<=value.\n",
+      " |  \n",
+      " |  __lt__(self, value, /)\n",
+      " |      Return self<value.\n",
+      " |  \n",
+      " |  __mod__(self, value, /)\n",
+      " |      Return self%value.\n",
+      " |  \n",
+      " |  __mul__(self, value, /)\n",
+      " |      Return self*value.\n",
+      " |  \n",
+      " |  __ne__(self, value, /)\n",
+      " |      Return self!=value.\n",
+      " |  \n",
+      " |  __neg__(self, /)\n",
+      " |      -self\n",
+      " |  \n",
+      " |  __new__(*args, **kwargs) from builtins.type\n",
+      " |      Create and return a new object.  See help(type) for accurate signature.\n",
+      " |  \n",
+      " |  __pos__(self, /)\n",
+      " |      +self\n",
+      " |  \n",
+      " |  __pow__(self, value, mod=None, /)\n",
+      " |      Return pow(self, value, mod).\n",
+      " |  \n",
+      " |  __radd__(self, value, /)\n",
+      " |      Return value+self.\n",
+      " |  \n",
+      " |  __rdivmod__(self, value, /)\n",
+      " |      Return divmod(value, self).\n",
+      " |  \n",
+      " |  __repr__(self, /)\n",
+      " |      Return repr(self).\n",
+      " |  \n",
+      " |  __rfloordiv__(self, value, /)\n",
+      " |      Return value//self.\n",
+      " |  \n",
+      " |  __rmod__(self, value, /)\n",
+      " |      Return value%self.\n",
+      " |  \n",
+      " |  __rmul__(self, value, /)\n",
+      " |      Return value*self.\n",
+      " |  \n",
+      " |  __round__(...)\n",
+      " |      Return the Integral closest to x, rounding half toward even.\n",
+      " |      When an argument is passed, work like built-in round(x, ndigits).\n",
+      " |  \n",
+      " |  __rpow__(self, value, mod=None, /)\n",
+      " |      Return pow(value, self, mod).\n",
+      " |  \n",
+      " |  __rsub__(self, value, /)\n",
+      " |      Return value-self.\n",
+      " |  \n",
+      " |  __rtruediv__(self, value, /)\n",
+      " |      Return value/self.\n",
+      " |  \n",
+      " |  __setformat__(...) from builtins.type\n",
+      " |      float.__setformat__(typestr, fmt) -> None\n",
+      " |      \n",
+      " |      You probably don't want to use this function.  It exists mainly to be\n",
+      " |      used in Python's test suite.\n",
+      " |      \n",
+      " |      typestr must be 'double' or 'float'.  fmt must be one of 'unknown',\n",
+      " |      'IEEE, big-endian' or 'IEEE, little-endian', and in addition can only be\n",
+      " |      one of the latter two if it appears to match the underlying C reality.\n",
+      " |      \n",
+      " |      Override the automatic determination of C-level floating point type.\n",
+      " |      This affects how floats are converted to and from binary strings.\n",
+      " |  \n",
+      " |  __str__(self, /)\n",
+      " |      Return str(self).\n",
+      " |  \n",
+      " |  __sub__(self, value, /)\n",
+      " |      Return self-value.\n",
+      " |  \n",
+      " |  __truediv__(self, value, /)\n",
+      " |      Return self/value.\n",
+      " |  \n",
+      " |  __trunc__(...)\n",
+      " |      Return the Integral closest to x between 0 and x.\n",
+      " |  \n",
+      " |  as_integer_ratio(...)\n",
+      " |      float.as_integer_ratio() -> (int, int)\n",
+      " |      \n",
+      " |      Return a pair of integers, whose ratio is exactly equal to the original\n",
+      " |      float and with a positive denominator.\n",
+      " |      Raise OverflowError on infinities and a ValueError on NaNs.\n",
+      " |      \n",
+      " |      >>> (10.0).as_integer_ratio()\n",
+      " |      (10, 1)\n",
+      " |      >>> (0.0).as_integer_ratio()\n",
+      " |      (0, 1)\n",
+      " |      >>> (-.25).as_integer_ratio()\n",
+      " |      (-1, 4)\n",
+      " |  \n",
+      " |  conjugate(...)\n",
+      " |      Return self, the complex conjugate of any float.\n",
+      " |  \n",
+      " |  fromhex(...) from builtins.type\n",
+      " |      float.fromhex(string) -> float\n",
+      " |      \n",
+      " |      Create a floating-point number from a hexadecimal string.\n",
+      " |      >>> float.fromhex('0x1.ffffp10')\n",
+      " |      2047.984375\n",
+      " |      >>> float.fromhex('-0x1p-1074')\n",
+      " |      -5e-324\n",
+      " |  \n",
+      " |  hex(...)\n",
+      " |      float.hex() -> string\n",
+      " |      \n",
+      " |      Return a hexadecimal representation of a floating-point number.\n",
+      " |      >>> (-0.1).hex()\n",
+      " |      '-0x1.999999999999ap-4'\n",
+      " |      >>> 3.14159.hex()\n",
+      " |      '0x1.921f9f01b866ep+1'\n",
+      " |  \n",
+      " |  is_integer(...)\n",
+      " |      Return True if the float is an integer.\n",
+      " |  \n",
+      " |  ----------------------------------------------------------------------\n",
+      " |  Data descriptors defined here:\n",
+      " |  \n",
+      " |  imag\n",
+      " |      the imaginary part of a complex number\n",
+      " |  \n",
+      " |  real\n",
+      " |      the real part of a complex number\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "help(g.T)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "provides help on Python's `float` class. To get the help for the temperature property, ask for the attribute of the class object itself:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Help on getset descriptor cantera._cantera.ThermoPhase.T:\n",
+      "\n",
+      "T\n",
+      "    Temperature [K].\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "help(g.__class__.T)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Help can also be obtained using the `?` syntax:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "g.species_index?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Chemical Equilibrium"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To set a gas mixture to a state of chemical equilibrium, use the `equilibrate` method:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "g = ct.Solution('gri30.xml')\n",
+    "g.TPX = 300.0, ct.one_atm, 'CH4:0.95, O2:2, N2:7.52'\n",
+    "g.equilibrate('TP')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The above statement sets the state of object `g` to the state of chemical equilibrium holding temperature and pressure fixed. Alternatively, the specific enthalpy and pressure can be held fixed:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "g.TPX = 300.0, ct.one_atm, 'CH4:0.95, O2:2, N2:7.52'\n",
+    "g.equilibrate('HP')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Other options are:\n",
+    "* 'UV' for fixed specific internal energy and specific volume\n",
+    "* 'SV' for fixed specific entropy and specific volume\n",
+    "* 'SP' for fixed specific entropy and pressure\n",
+    "\n",
+    "How can you tell if `equilibrate` has correctly found the chemical equilibrium state? One way is to verify that the net rates of progress of all reversible reactions are zero. Here is the code to do this:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "g.TPX = 300.0, ct.one_atm, 'CH4:0.95, O2:2, N2:7.52'\n",
+    "g.equilibrate('HP')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     0   -3.523e-16  \n",
+      "     1    3.517e-15  \n",
+      "     2    1.968e-15  \n",
+      "     3    1.667e-15  \n",
+      "     4   -3.976e-15  \n",
+      "     5    3.257e-15  \n",
+      "     6    1.047e-14  \n",
+      "     7    1.227e-14  \n",
+      "     8    1.066e-14  \n",
+      "     9    -7.14e-15  \n",
+      "    10   -9.658e-15  \n",
+      "    11   -2.026e-15  \n",
+      "    12     1.72e-15  \n",
+      "    13   -3.656e-15  \n",
+      "    14    3.864e-15  \n",
+      "    15   -5.203e-15  \n",
+      "    16   -8.891e-15  \n",
+      "    17    9.887e-15  \n",
+      "    18    1.468e-14  \n",
+      "    19    5.152e-15  \n",
+      "    20   -8.548e-15  \n",
+      "    21   -3.979e-15  \n",
+      "    22   -5.502e-15  \n",
+      "    23   -3.935e-15  \n",
+      "    24    7.261e-15  \n",
+      "    25    1.575e-15  \n",
+      "    26    5.639e-16  \n",
+      "    27    1.851e-14  \n",
+      "    28   -7.515e-15  \n",
+      "    29   -3.248e-15  \n",
+      "    30    -1.01e-14  \n",
+      "    31    1.118e-15  \n",
+      "    32    1.244e-15  \n",
+      "    33    1.414e-15  \n",
+      "    34    1.087e-15  \n",
+      "    35    1.368e-15  \n",
+      "    37    2.706e-15  \n",
+      "    38    3.131e-15  \n",
+      "    39    3.087e-15  \n",
+      "    40   -4.038e-16  \n",
+      "    41    6.529e-15  \n",
+      "    42    1.232e-15  \n",
+      "    43    1.752e-16  \n",
+      "    44   -1.633e-15  \n",
+      "    45   -1.445e-15  \n",
+      "    46   -3.294e-15  \n",
+      "    47   -4.786e-15  \n",
+      "    48    1.783e-15  \n",
+      "    49    4.888e-15  \n",
+      "    50    5.753e-16  \n",
+      "    51    1.002e-14  \n",
+      "    52   -1.482e-14  \n",
+      "    53   -5.721e-15  \n",
+      "    54    5.229e-15  \n",
+      "    55    8.253e-15  \n",
+      "    56    1.293e-14  \n",
+      "    57    5.256e-15  \n",
+      "    58    -5.61e-15  \n",
+      "    59    3.572e-15  \n",
+      "    60    2.735e-15  \n",
+      "    61   -3.477e-15  \n",
+      "    62   -1.641e-14  \n",
+      "    63   -1.169e-14  \n",
+      "    64   -8.777e-15  \n",
+      "    65   -8.647e-15  \n",
+      "    66    -1.53e-14  \n",
+      "    67    1.754e-14  \n",
+      "    68    1.592e-14  \n",
+      "    69     5.17e-15  \n",
+      "    70    1.238e-15  \n",
+      "    71   -5.735e-15  \n",
+      "    72   -3.452e-15  \n",
+      "    73    1.267e-14  \n",
+      "    74    1.141e-14  \n",
+      "    75   -2.325e-15  \n",
+      "    76   -7.411e-15  \n",
+      "    77   -5.045e-15  \n",
+      "    78    3.647e-15  \n",
+      "    79    4.799e-16  \n",
+      "    80    1.113e-14  \n",
+      "    81    8.567e-16  \n",
+      "    82   -1.085e-14  \n",
+      "    83    2.398e-16  \n",
+      "    84    2.703e-15  \n",
+      "    85    1.714e-15  \n",
+      "    86   -1.946e-15  \n",
+      "    87   -2.819e-15  \n",
+      "    88   -2.815e-15  \n",
+      "    89    1.145e-15  \n",
+      "    90    8.714e-15  \n",
+      "    91   -3.909e-16  \n",
+      "    92    7.483e-15  \n",
+      "    93   -3.751e-15  \n",
+      "    94   -7.769e-15  \n",
+      "    95   -5.841e-15  \n",
+      "    96   -5.887e-15  \n",
+      "    97   -7.884e-15  \n",
+      "    98   -6.511e-15  \n",
+      "    99   -3.743e-15  \n",
+      "   100      5.4e-15  \n",
+      "   101   -1.078e-14  \n",
+      "   102   -1.433e-14  \n",
+      "   103    1.765e-14  \n",
+      "   104    1.634e-14  \n",
+      "   105   -4.961e-15  \n",
+      "   106   -7.888e-15  \n",
+      "   107   -8.536e-15  \n",
+      "   108   -2.246e-15  \n",
+      "   109     3.43e-15  \n",
+      "   110   -3.533e-15  \n",
+      "   111    4.954e-15  \n",
+      "   112    8.932e-15  \n",
+      "   113    8.103e-16  \n",
+      "   114    6.894e-15  \n",
+      "   115    6.857e-15  \n",
+      "   116    7.082e-15  \n",
+      "   117    5.337e-15  \n",
+      "   118    7.972e-15  \n",
+      "   119    -7.05e-15  \n",
+      "   120    8.362e-15  \n",
+      "   121    8.724e-15  \n",
+      "   122    3.169e-15  \n",
+      "   123    1.498e-15  \n",
+      "   124    5.664e-15  \n",
+      "   125    -9.18e-16  \n",
+      "   126    -6.89e-15  \n",
+      "   127     8.95e-15  \n",
+      "   128    5.307e-15  \n",
+      "   129   -1.608e-14  \n",
+      "   130   -6.056e-15  \n",
+      "   131   -3.569e-15  \n",
+      "   132   -2.092e-15  \n",
+      "   133    1.477e-14  \n",
+      "   135    2.863e-15  \n",
+      "   136    6.742e-15  \n",
+      "   137   -5.457e-15  \n",
+      "   138       -2e-15  \n",
+      "   139    9.941e-16  \n",
+      "   140    1.791e-14  \n",
+      "   141    1.717e-16  \n",
+      "   143    1.282e-14  \n",
+      "   144     7.28e-15  \n",
+      "   145    3.122e-15  \n",
+      "   146   -2.349e-15  \n",
+      "   147            0  \n",
+      "   148   -5.316e-15  \n",
+      "   149   -2.234e-15  \n",
+      "   150    1.498e-16  \n",
+      "   151    1.669e-16  \n",
+      "   152    7.176e-15  \n",
+      "   153    8.489e-15  \n",
+      "   154    1.237e-14  \n",
+      "   155    1.843e-15  \n",
+      "   156    1.168e-14  \n",
+      "   157    1.859e-15  \n",
+      "   158    5.272e-15  \n",
+      "   159    1.908e-14  \n",
+      "   160    7.055e-15  \n",
+      "   161    6.168e-15  \n",
+      "   162    1.769e-14  \n",
+      "   163    1.363e-14  \n",
+      "   164    9.954e-15  \n",
+      "   165   -7.023e-16  \n",
+      "   166   -9.573e-16  \n",
+      "   167    1.296e-14  \n",
+      "   168   -1.298e-15  \n",
+      "   169   -1.165e-16  \n",
+      "   170   -3.422e-15  \n",
+      "   171    2.924e-15  \n",
+      "   172   -6.997e-15  \n",
+      "   173    3.826e-15  \n",
+      "   174   -1.127e-14  \n",
+      "   175    7.843e-15  \n",
+      "   176    1.905e-14  \n",
+      "   177    3.947e-15  \n",
+      "   178     2.14e-15  \n",
+      "   179   -1.278e-16  \n",
+      "   180    5.412e-15  \n",
+      "   181   -1.486e-15  \n",
+      "   182    2.376e-15  \n",
+      "   183   -5.369e-15  \n",
+      "   184    7.497e-16  \n",
+      "   185    5.032e-15  \n",
+      "   186    3.142e-15  \n",
+      "   187   -1.857e-15  \n",
+      "   188    1.647e-16  \n",
+      "   189            0  \n",
+      "   190   -4.155e-16  \n",
+      "   191     2.79e-15  \n",
+      "   192   -9.124e-16  \n",
+      "   193    5.714e-15  \n",
+      "   194    1.285e-16  \n",
+      "   195   -1.533e-15  \n",
+      "   196    8.673e-15  \n",
+      "   197    3.874e-15  \n",
+      "   198    4.242e-15  \n",
+      "   199    1.016e-15  \n",
+      "   200    3.335e-15  \n",
+      "   201    2.287e-15  \n",
+      "   202    2.877e-15  \n",
+      "   203   -5.853e-15  \n",
+      "   204   -5.634e-15  \n",
+      "   205   -8.771e-15  \n",
+      "   206    1.975e-15  \n",
+      "   207    -3.69e-15  \n",
+      "   208    1.739e-15  \n",
+      "   209    3.542e-15  \n",
+      "   210    3.663e-15  \n",
+      "   211    6.307e-15  \n",
+      "   212   -5.348e-15  \n",
+      "   213    1.631e-15  \n",
+      "   214   -1.077e-14  \n",
+      "   215   -8.503e-15  \n",
+      "   216    5.191e-15  \n",
+      "   217    1.356e-15  \n",
+      "   218    -6.15e-15  \n",
+      "   219     1.09e-14  \n",
+      "   220   -2.553e-15  \n",
+      "   221   -5.329e-15  \n",
+      "   222   -2.225e-15  \n",
+      "   223    -2.79e-15  \n",
+      "   224    -3.45e-15  \n",
+      "   225   -7.203e-15  \n",
+      "   226   -5.324e-15  \n",
+      "   227   -3.987e-15  \n",
+      "   228   -3.604e-15  \n",
+      "   229    1.934e-15  \n",
+      "   230    5.822e-15  \n",
+      "   231    3.215e-15  \n",
+      "   232    4.562e-15  \n",
+      "   233    4.919e-15  \n",
+      "   234   -6.439e-15  \n",
+      "   235    3.684e-15  \n",
+      "   236    3.923e-15  \n",
+      "   237   -6.675e-15  \n",
+      "   238     1.37e-15  \n",
+      "   239    1.173e-15  \n",
+      "   240   -2.136e-15  \n",
+      "   241    6.901e-15  \n",
+      "   242    6.969e-15  \n",
+      "   243    3.423e-15  \n",
+      "   244    6.729e-15  \n",
+      "   245    1.914e-15  \n",
+      "   246    8.995e-15  \n",
+      "   247    4.215e-15  \n",
+      "   248   -1.757e-15  \n",
+      "   249     5.52e-15  \n",
+      "   250    3.859e-15  \n",
+      "   251   -5.202e-15  \n",
+      "   252      3.8e-15  \n",
+      "   253    5.674e-16  \n",
+      "   254     7.12e-15  \n",
+      "   255    4.909e-15  \n",
+      "   256    3.759e-15  \n",
+      "   257    1.723e-15  \n",
+      "   258    2.183e-15  \n",
+      "   259    1.813e-15  \n",
+      "   260    1.983e-15  \n",
+      "   261    1.038e-14  \n",
+      "   262    1.239e-14  \n",
+      "   263     1.25e-14  \n",
+      "   264    1.031e-14  \n",
+      "   265     2.03e-14  \n",
+      "   266    2.055e-14  \n",
+      "   267    3.579e-15  \n",
+      "   268    7.339e-15  \n",
+      "   269   -5.379e-15  \n",
+      "   270     1.83e-15  \n",
+      "   271    5.541e-15  \n",
+      "   272   -1.147e-14  \n",
+      "   273    1.457e-14  \n",
+      "   274    4.302e-15  \n",
+      "   275            0  \n",
+      "   276   -3.678e-15  \n",
+      "   277    3.249e-15  \n",
+      "   278   -4.618e-15  \n",
+      "   279    2.648e-15  \n",
+      "   280    1.873e-15  \n",
+      "   281   -1.093e-14  \n",
+      "   282    5.548e-15  \n",
+      "   284    9.713e-15  \n",
+      "   285   -1.111e-14  \n",
+      "   286   -1.856e-15  \n",
+      "   288    3.514e-15  \n",
+      "   290     3.42e-15  \n",
+      "   293    2.601e-15  \n",
+      "   294    4.142e-16  \n",
+      "   295     1.82e-14  \n",
+      "   298    6.152e-15  \n",
+      "   303    8.282e-15  \n",
+      "   307   -3.482e-15  \n",
+      "   308   -4.115e-15  \n",
+      "   309   -1.471e-14  \n",
+      "   310    4.189e-16  \n",
+      "   311   -7.986e-15  \n",
+      "   312   -9.514e-15  \n",
+      "   313   -7.831e-15  \n",
+      "   314   -8.056e-15  \n",
+      "   315   -7.731e-15  \n",
+      "   316     6.45e-15  \n",
+      "   317    -8.62e-15  \n",
+      "   318    5.689e-15  \n",
+      "   319    6.368e-15  \n",
+      "   320    1.457e-14  \n",
+      "   321    3.124e-14  \n",
+      "   322    1.235e-14  \n",
+      "   324    1.931e-14  \n"
+     ]
+    }
+   ],
+   "source": [
+    "rf = g.forward_rates_of_progress\n",
+    "rr = g.reverse_rates_of_progress\n",
+    "for i in range(g.n_reactions):\n",
+    "    if g.is_reversible(i) and rf[i] != 0.0:\n",
+    "        print('  %4i   %10.4g  ' % (i, (rf[i] - rr[i])/rf[i]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If the magnitudes of the numbers in this list are all very small (which in this case they are), then each reversible reaction is very nearly equilibrated, which only occurs if the gas is in chemical equilibrium.\n",
+    "\n",
+    "You might be wondering how `equilibrate` works. (Then again, you might not.) Method `equilibrate` invokes Cantera's chemical equilibrium solver, which uses an element potential method. The element potential method is one of a class of equivalent *nonstoichiometric* methods that all have the characteristic that the probelm reduces to solving a set of M nonlinear algebraic equations, where M is the number of elements (not species). The so-called *stoichiometric* methods, on the other hand (including the Gibbs minimization), require solving K nonlinear equations, where K is the number of species (usually K >> M). See Smith and Missen's \"Chemical Reaction Equilibrium Analysis\" for more information on the various algorithms and their characteristics.\n",
+    "\n",
+    "Cantera uses a damped Newton method to solve these equations, and does a few other things to generate a good starting guess and to produce a reasonably robust algorithm. If you want to know more about the details, look at the on-line documentated source code of Cantera C++ class 'ChemEquil.h'."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Chemical Kinetics"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**[Solution](http://cantera.github.io/docs/sphinx/html/cython/importing.html#cantera.Solution)** objects are also **[Kinetics](http://cantera.github.io/docs/sphinx/html/cython/kinetics.html#cantera.Kinetics)** objects, and provide all of the methods necessary to compute the thermodynamic quantities associated with each reaction, reaction rates, and species creation and destruction rates. They also provide methods to inspect the quantities that define each reaction, such as the rate constants and the stoichiometric coefficients. The rate calculation functions are used extensively within Cantera's *[reactor network model](http://cantera.github.io/docs/sphinx/html/cython/zerodim.html#sec-cython-zerodim)* and *[1D flame model](http://cantera.github.io/docs/sphinx/html/cython/onedim.html#sec-cython-onedim)*.\n",
+    "\n",
+    "Information about individual reactions that are independent of the thermodynamic state can be obtained by accessing **[Reaction](http://cantera.github.io/docs/sphinx/html/cython/kinetics.html#cantera.Reaction)** objects with the **[Kinetics.reaction](http://cantera.github.io/docs/sphinx/html/cython/kinetics.html#cantera.Kinetics.reaction)** method:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<ElementaryReaction: H2 + O <=> H + OH>"
+      ]
+     },
+     "execution_count": 32,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "g = ct.Solution('gri30.cti')\n",
+    "r = g.reaction(2)  # get a Reaction object\n",
+    "r"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'H2': 1.0, 'O': 1.0}"
+      ]
+     },
+     "execution_count": 33,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "r.reactants"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'H': 1.0, 'OH': 1.0}"
+      ]
+     },
+     "execution_count": 34,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "r.products"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Arrhenius(A=38.7, b=2.7, E=2.61918e+07)"
+      ]
+     },
+     "execution_count": 35,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "r.rate"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If we are interested in only certain types of reactions, we can use this information to filter the full list of reactions to find just the ones of interest. For example, here we find the indices of just those reactions which convert **`CO`** into **`CO2`**:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CO + O (+M) <=> CO2 (+M)\n",
+      "CO + O2 <=> CO2 + O\n",
+      "CO + OH <=> CO2 + H\n",
+      "CO + HO2 <=> CO2 + OH\n"
+     ]
+    }
+   ],
+   "source": [
+    "II = [i for i, r in enumerate(g.reactions()) if 'CO' in r.reactants and 'CO2' in r.products]\n",
+    "\n",
+    "for i in II:\n",
+    "    print(g.reaction(i).equation)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "(Actually, we should also include the reactions where the reaction is written such that `CO2` is a reactant and `CO` is a product, but for this example, we'll just stick to this smaller set of reactions.) Now, let's set the composition to an interesting state:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "g.TPX = 300, 101325, {'CH4':0.6, 'O2':1.0, 'N2':3.76}\n",
+    "g.equilibrate('HP')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can verify that this is an equilibrium state by seeing that the net reactions rates are essentially zero:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([  1.76182853e-19,  -5.29395592e-21,   5.55111512e-17,\n",
+       "         5.08219768e-20])"
+      ]
+     },
+     "execution_count": 38,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "g.net_rates_of_progress[II]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now let's see what happens if we decrease the temperature of the mixture:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([  3.18644948e-05,   5.00489577e-08,   1.05964923e-01,\n",
+       "         2.89502609e-06])"
+      ]
+     },
+     "execution_count": 39,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "g.TP = g.T-100, None\n",
+    "g.net_rates_of_progress[II]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "All of the reaction rates are positive, favoring the formation of `CO2` from `CO`, with the third reaction, `CO + OH <=> CO2 + H` proceeding the fastest. If we look at the enthalpy change associated with each of these reactions:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([ -5.33034657e+08,  -2.23248515e+07,  -8.76650086e+07,\n",
+       "        -2.49169628e+08])"
+      ]
+     },
+     "execution_count": 40,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "g.delta_enthalpy[II]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "we see that the change is negative in each case, indicating a net release of thermal energy. The total heat release rate can be computed either from the reaction rates:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "-58013370.720881224"
+      ]
+     },
+     "execution_count": 41,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "np.dot(g.net_rates_of_progress, g.delta_enthalpy)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "or from the species production rates:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "-58013370.720881134"
+      ]
+     },
+     "execution_count": 42,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "np.dot(g.net_production_rates, g.partial_molar_enthalpies)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The contribution from just the selected reactions is:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "-9307123.262565529"
+      ]
+     },
+     "execution_count": 43,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "np.dot(g.net_rates_of_progress[II], g.delta_enthalpy[II])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "or about 16% of the total heat release rate."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
All that was done here was the Cantera Python Tutorial from the Cantera
website was transferred into a Jupyter Notebook.  Some language was
changed in order to keep things sensible, but most was kept the same as the original.